### PR TITLE
Final version of the French translation

### DIFF
--- a/plugin/language.h
+++ b/plugin/language.h
@@ -44,11 +44,11 @@ language_container_t language_english_us = {
 
 // by jokira & devnoname120 & CelesteBlue-dev & chronoss09
 language_container_t language_french = {
-  "Paramètres HENkaku",
-  "Activer le spoof PSN",
-  "Autoriser l'installation des homebrews non sécurisés",
+  "Paramètres de HENkaku",
+  "Activer le spoof du PSN",
+  "Autoriser l'installation de homebrews non sécurisés",
   "Les homebrews non sécurisés peuvent endommager votre système de façon permanente s'ils sont mal utilisés, mal configurés, ou malveillants. Prenez garde en activant ce paramètre.",
-  "Activer la version spoofée",
+  "Activer le spoof de version",
   "Version spoofée",
   "Action du bouton ○",
   "Valider",


### PR DESCRIPTION
Here are precise arguments about why my version of the translation is correct, while the other version is factually incorrect.

- Le terme « Paramètres HENkaku » est grammaticalement incorrect en plus de sonner faux. Omettre le déterminant est un anglicisme qui n'est acceptable que s'il n'y a pas assez de place pour l'inclure, ce qui n'est manifestement pas le cas ici.
- De même, « spoof PSN » est incorrect.
- « l'installation **des** homebrews non sécurisés » est faux car il s'agit ici d'un **article indéfini non contracté**. La formulation correcte est donc bien « l'installation **de** homebrews non sécurisés ».

Références pour les incrédules :
- http://www.francaisfacile.com/exercices/exercice-francais-2/exercice-francais-11349.php
- http://www.lepointdufle.net/ressources_fle/articles_de_du1.htm