### PR TITLE
Fix build order and link to the internal stubs library

### DIFF
--- a/plugin/CMakeLists.txt
+++ b/plugin/CMakeLists.txt
@@ -18,7 +18,7 @@ include_directories(
 )
 
 link_directories(
-  ${CMAKE_CURRENT_BINARY_DIR}
+  ${CMAKE_CURRENT_BINARY_DIR}/henkaku-stubs
 )
 
 if (NOT ${RELEASE})
@@ -76,6 +76,8 @@ target_link_libraries(kernel
   SceModulemgrForKernel_stub
   SceThreadmgrForDriver_stub
 )
+
+add_dependencies(user henkaku-stubs)
 
 set_target_properties(kernel
   PROPERTIES LINK_FLAGS "-nostdlib"


### PR DESCRIPTION
When compiling henkaku using a fresh SDK (plus taihen libraries installed), the build fails because:

* It tries to link aganist the henkaku-stubs library that doesn't exists on the library path yet
* It tries to build the user henkaku module before the henkaku-stubs library

The proposed patch adds the henkaku-stubs target as a dep to the user plugin, then corrects the link directory so it can find the stub library.