### PR TITLE
Cosmetic changes

### DIFF
--- a/payload/loader.c
+++ b/payload/loader.c
@@ -10,11 +10,11 @@ void __attribute__((noreturn)) loader(uint32_t sysmem_addr, void *second_payload
 	uint32_t sysmem_base = sysmem_addr;
 	// BEGIN 3.60
 	void (*set_crash_flag)(int) = (void *)(sysmem_base + 0x1990d);
-	void (*debug_print_local)(char *s, ...) = (void*)(sysmem_base + 0x1A155);
-	uint32_t (*ksceKernelAllocMemBlock)(const char *s, uint32_t type, uint32_t size, void *pargs) = (void*)(sysmem_base + 0xA521);
-	uint32_t (*ksceKernelGetMemBlockBase)(uint32_t blkid, void **base) = (void*)(sysmem_base + 0x1F15);
+	void (*debug_print_local)(char *s, ...) = (void*)(sysmem_base + 0x1a155);
+	uint32_t (*ksceKernelAllocMemBlock)(const char *s, uint32_t type, uint32_t size, void *pargs) = (void*)(sysmem_base + 0xa521);
+	uint32_t (*ksceKernelGetMemBlockBase)(uint32_t blkid, void **base) = (void*)(sysmem_base + 0x1f15);
 	void (*ksceKernelCpuUnrestrictedMemcpy)() = (void*)(sysmem_base + 0x23095);
-	void (*ksceKernelMemcpyUserToKernel)(void *dst, void *src, uint32_t sz) = (void*)(sysmem_base + 0x825D);
+	void (*ksceKernelMemcpyUserToKernel)(void *dst, void *src, uint32_t sz) = (void*)(sysmem_base + 0x825d);
 	// END 3.60
 
 #if !RELEASE

--- a/payload/loader.c
+++ b/payload/loader.c
@@ -9,20 +9,16 @@
 void __attribute__((noreturn)) loader(uint32_t sysmem_addr, void *second_payload) {
 	uint32_t sysmem_base = sysmem_addr;
 	// BEGIN 3.60
-	void (*SceDebugForKernel_F857CDD6_set_crash_flag)(int) = (void *)(sysmem_base + 0x1990d);
+	void (*set_crash_flag)(int) = (void *)(sysmem_base + 0x1990d);
 	void (*debug_print_local)(char *s, ...) = (void*)(sysmem_base + 0x1A155);
 	uint32_t (*ksceKernelAllocMemBlock)(const char *s, uint32_t type, uint32_t size, void *pargs) = (void*)(sysmem_base + 0xA521);
-	uint32_t (*getbase_0xA841EDDA)(uint32_t blkid, void **base) = (void*)(sysmem_base + 0x1F15);
-	// void (*sysmem_remap)(uint32_t blkid, uint32_t type) = (void*)(sysmem_base + 0xA74D);
-	// void (*flush_cache)(void *addr, uint32_t size) = (void*)(sysmem_base + 0x22FCD);
-	void (*dacr_memcpy)() = (void*)(sysmem_base + 0x23095);
+	uint32_t (*ksceKernelGetMemBlockBase)(uint32_t blkid, void **base) = (void*)(sysmem_base + 0x1F15);
+	void (*ksceKernelCpuUnrestrictedMemcpy)() = (void*)(sysmem_base + 0x23095);
 	void (*ksceKernelMemcpyUserToKernel)(void *dst, void *src, uint32_t sz) = (void*)(sysmem_base + 0x825D);
-	//void (*aes_setkey_0xf12b6451)(void *ctx, uint32_t blocksize, uint32_t keysize, void *key) = (void*)(sysmem_base + 0x1d8d9);
-	//void (*aes_decrypt_0xd8678061)(void *ctx, void *src, void *dst) = (void*)(sysmem_base + 0x1baf5);
 	// END 3.60
 
 #if !RELEASE
-	SceDebugForKernel_F857CDD6_set_crash_flag(0);
+	set_crash_flag(0);
 	debug_print_local("sysmem: %x\n", sysmem_base);
 #endif
 	__asm__ volatile ("cpsid aif"); // disable interrupts
@@ -32,11 +28,11 @@ void __attribute__((noreturn)) loader(uint32_t sysmem_addr, void *second_payload
 	uint32_t rx_block = ksceKernelAllocMemBlock(&empty_string, 0x1020D005, RX_BLOCK_SIZE, NULL);
 	void *rw_base;
 	void *rx_base;
-	getbase_0xA841EDDA(rw_block, &rw_base);
-	getbase_0xA841EDDA(rx_block, &rx_base);
+	ksceKernelGetMemBlockBase(rw_block, &rw_base);
+	ksceKernelGetMemBlockBase(rx_block, &rx_base);
 	ksceKernelMemcpyUserToKernel(rw_base, second_payload, PAYLOAD_SIZE);
 
-	dacr_memcpy(rx_base, rw_base, PAYLOAD_SIZE);
+	ksceKernelCpuUnrestrictedMemcpy(rx_base, rw_base, PAYLOAD_SIZE);
 
 	void *sp = (char*)rw_base + RW_BLOCK_SIZE - 0x100;
 	*(int *)sp = PAYLOAD_SIZE;

--- a/payload/payload.c
+++ b/payload/payload.c
@@ -713,17 +713,17 @@ void resolve_imports(unsigned sysmem_base) {
 		sbl_set_up_buffer = find_export(sblauthmgr_info, 0x89CCDA2C);
 		sbl_decrypt = find_export(sblauthmgr_info, 0xBC422443);
 
-		ksceKernelCpuIcacheAndL2WritebackInvalidateRange = find_export(sysmem_info, 0x19f17bd0);
+		ksceKernelCpuIcacheAndL2WritebackInvalidateRange = find_export(sysmem_info, 0x19F17BD0);
 		ksceKernelCpuDcacheWritebackRange = find_export(sysmem_info, 0x9CB9F0CE);
 		ksceIoOpen = find_export(iofilemgr_info, 0x75192972);
-		ksceIoClose = find_export(iofilemgr_info, 0xf99dd8a3);
-		ksceIoWrite = find_export(iofilemgr_info, 0x21ee91f0);
+		ksceIoClose = find_export(iofilemgr_info, 0xF99DD8A3);
+		ksceIoWrite = find_export(iofilemgr_info, 0x21EE91F0);
 		ksceAppMgrLaunchAppByPath = find_export(appmgr_info, 0xB0A37065);
 		ksceKernelLoadModule = find_export(modulemgr_info, 0x86D8D634);
 		ksceKernelStartModule = find_export(modulemgr_info, 0x0675B682);
 		ksceKernelSetSyscall = find_export(modulemgr_info, 0xB427025E);
-		ksceKernelFreeMemBlock = find_export(sysmem_info, 0x9e1c61);
-		ksceKernelFindMemBlockByAddr = find_export(sysmem_info, 0x8a1742f6);
+		ksceKernelFreeMemBlock = find_export(sysmem_info, 0x009E1C61);
+		ksceKernelFindMemBlockByAddr = find_export(sysmem_info, 0x8A1742F6);
 		ksceKernelCreateThread = find_export(threadmgr_info, 0xC6674E7D);
 		ksceKernelStartThread = find_export(threadmgr_info, 0x21F5419B);
 		ksceKernelExitDeleteThread = find_export(threadmgr_info, 0x1D17DECF);
@@ -749,7 +749,7 @@ void __attribute__ ((section (".text.start"))) payload(uint32_t sysmem_addr, voi
 	uint32_t sysmem_base = sysmem_addr;
 	int ret;
 	// BEGIN 3.60
-	void (*debug_print_local)(char *s, ...) = (void*)(sysmem_base + 0x1A155);
+	void (*debug_print_local)(char *s, ...) = (void*)(sysmem_base + 0x1a155);
 	// END 3.60
 
 	DACR_OFF(
@@ -788,7 +788,7 @@ void __attribute__ ((section (".text.start"))) payload(uint32_t sysmem_addr, voi
 	void *base;
 	ret = ksceKernelGetMemBlockBase(rx_block, &base);
 	LOG("ksceKernelGetMemBlockBase: %x, %x", ret, base);
-	ksceKernelCpuDcacheWritebackRange((uint32_t)base, (rx_size + 0x1f) & ~0x1f);
+	ksceKernelCpuDcacheWritebackRange((uint32_t)base, (rx_size + 0x1F) & ~0x1F);
 
 	int tid;
 	LOG("starting kernel thread");

--- a/plugin/CMakeLists.txt
+++ b/plugin/CMakeLists.txt
@@ -73,7 +73,6 @@ target_link_libraries(kernel
   SceSysclibForDriver_stub
   SceIofilemgrForDriver_stub
   SceDebugForDriver_stub
-  SceModulemgrForKernel_stub
   SceThreadmgrForDriver_stub
 )
 

--- a/plugin/henkaku.h
+++ b/plugin/henkaku.h
@@ -37,6 +37,6 @@ typedef struct {
 #define HENKAKU_CONFIG_MAGIC (0x4C434C4D)
 #define CONFIG_PATH "ur0:tai/henkaku_config.bin"
 #define OLD_CONFIG_PATH "ux0:temp/app_work/MLCL00001/rec/config.bin"
-#define SPOOF_VERSION (0x3650000)
+#define SPOOF_VERSION (0x3680000)
 
 #endif // HENKAKU_HEADER


### PR DESCRIPTION
With small changes like
- simplified check in sbl_parse_header_patched to `res < 0`
- use 3.68 as spoofed version
- use _vshSblGetSystemSwVersion for real fw instead of hardcoding 3.60